### PR TITLE
feat: persist tasks in localStorage (closes #1)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,18 @@ const taskCategorySelect = document.getElementById("task-category");
 const taskList = document.getElementById("task-list");
 const searchInput = document.getElementById("search-input");
 
-let tasks = [...initialTasks];
+const STORAGE_KEY = "tasks";
+
+function loadTasks() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  return saved ? JSON.parse(saved) : [...initialTasks];
+}
+
+function saveTasks() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+}
+
+let tasks = loadTasks();
 let searchTerm = "";
 
 function renderTasks() {
@@ -65,6 +76,7 @@ function addTask(title, category) {
   };
 
   tasks.unshift(newTask);
+  saveTasks();
   renderTasks();
 }
 
@@ -75,11 +87,13 @@ function toggleTask(taskId) {
       : task
   );
 
+  saveTasks();
   renderTasks();
 }
 
 function deleteTask(taskId) {
   tasks = tasks.filter((task) => task.id !== taskId);
+  saveTasks();
   renderTasks();
 }
 


### PR DESCRIPTION
## What changed

- Added `loadTasks()` — reads tasks from `localStorage` on startup, falling
  back to the seeded `initialTasks` if nothing is stored.
- Added `saveTasks()` — serializes the current `tasks` array to `localStorage`.
- Replaced the direct `[...initialTasks]` assignment with `loadTasks()`.
- Called `saveTasks()` inside `addTask`, `toggleTask`, and `deleteTask` so
  every mutation is immediately persisted.

Only `src/app.js` was modified. `src/data.js` and `index.html` are unchanged.

## Why it changed

Tasks previously lived only in memory and were lost on every page reload.
This change fulfills the persistence requirements described in #1 so users
don't lose their task state between sessions.

## Testing

1. Open the app in a browser.
2. Add a task, complete another, and delete one.
3. Hard-reload the page — all changes should survive.
4. Clear `localStorage` (`localStorage.clear()` in DevTools) and reload —
   the three seeded tasks should reappear.

## Notes / Limitations

- No `try/catch` around `JSON.parse` — malformed storage data will throw.
- No cross-tab sync (`storage` event not implemented).
- Storage key `"tasks"` is generic; may collide if the same origin hosts
  other apps.

Closes #1